### PR TITLE
Feat: Build input component

### DIFF
--- a/src/components/input/Input.jsx
+++ b/src/components/input/Input.jsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+const Input = ({ inputType="text", handleChange=(event)=>{console.log("An input is without handler function!!!")}, inputValue="",inputClasses="",inputName="",inputId="",inputPlaceholder="" }) => {
+  return (
+  
+    <input
+      type={inputType}
+      onChange={(event) => {
+        handleChange(event);
+      }}
+      value={inputValue}
+      className={"shadow appearance-none border rounded py-2 px-3 text-gray-700 leading-tight "+inputClasses}
+      name={inputName}
+      id={inputId}
+    placeholder={inputPlaceholder}
+    />
+  );
+};
+
+export default Input;


### PR DESCRIPTION
I have built the reusable dynamic input component, I added main props to it and the variables that can be sent as props are the following:
{ inputType="text", handleChange=(event)=>{console.log("An input is without handler function!!!")}, inputValue="",inputClasses="",inputName="",inputId="",inputPlaceholder="" }.
as you can see the default value if not sent for any input is going to be of type text, moreover adding change handler function for input is mandatory and we all should use the controlled form concept.
so if you will not add change handler function, the component will notify you by typing An input is without handler function!!! to remind the developer to add it.