### PR TITLE
Feat: add description component

### DIFF
--- a/src/components/Description/Description.jsx
+++ b/src/components/Description/Description.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Description = ({ classes, text }) => {
+  return <p className={'text-base font-normal ' + classes}>{text}</p>;
+};
+
+export default Description;


### PR DESCRIPTION
add description component which is a paragraph tag whith some default
classes, add two props to this component those are the inner text and
the classes to override or add to the default classes.
closes  #22 